### PR TITLE
Drop "gpiod" project name because gpiod is a library name

### DIFF
--- a/gpio/part9/CMakeLists.txt
+++ b/gpio/part9/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 
-project(gpiod LANGUAGES C)
+project(example LANGUAGES C)
 
-add_executable(example example.c)
-target_link_libraries(example gpiod)
+add_executable(${PROJECT_NAME} example.c)
+target_link_libraries(${PROJECT_NAME} gpiod)


### PR DESCRIPTION
also add CMake variable ${PROJECT_NAME} to avoid using "example" 3 times...